### PR TITLE
Update Forge and mappings, rework reloadable guns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,13 @@
 buildscript {
     repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
+        mavenLocal()
+        maven { url = "https://files.minecraftforge.net/maven" }
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
-
 
 version = "0.7.5"
 group = "org.silvercatcher.reforged"
@@ -20,9 +19,9 @@ compileJava {
 }
 
 minecraft {
-    version = "1.12.2-14.23.1.2606"
+    version = "1.12.2-14.23.5.2847"
     runDir = "run"
-    mappings = "snapshot_20180129"
+    mappings = "stable_39"
 }
 
 dependencies {}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/src/main/java/org/silvercatcher/reforged/ReforgedMod.java
+++ b/src/main/java/org/silvercatcher/reforged/ReforgedMod.java
@@ -36,7 +36,7 @@ public class ReforgedMod {
 
 	public static final CreativeTabs tabReforged = new CreativeTabs(ID) {
 		@Override
-		public ItemStack getTabIconItem() {
+		public ItemStack createIcon() {
 			return new ItemStack(ReforgedAdditions.IRON_BATTLE_AXE);
 		}
 	};

--- a/src/main/java/org/silvercatcher/reforged/ReforgedRegistry.java
+++ b/src/main/java/org/silvercatcher/reforged/ReforgedRegistry.java
@@ -50,11 +50,11 @@ public class ReforgedRegistry {
 		}
 
 		if (GlobalValues.MUSKET) {
-			registrationList.add(ReforgedAdditions.MUSKET_BARREL = new Item().setUnlocalizedName("musket_barrel")
+			registrationList.add(ReforgedAdditions.MUSKET_BARREL = new Item().setTranslationKey("musket_barrel")
 					.setCreativeTab(ReforgedMod.tabReforged));
 			registrationList.add(ReforgedAdditions.BLUNDERBUSS_BARREL = new Item()
-					.setUnlocalizedName("blunderbuss_barrel").setCreativeTab(ReforgedMod.tabReforged));
-			registrationList.add(ReforgedAdditions.GUN_STOCK = new Item().setUnlocalizedName("gun_stock")
+					.setTranslationKey("blunderbuss_barrel").setCreativeTab(ReforgedMod.tabReforged));
+			registrationList.add(ReforgedAdditions.GUN_STOCK = new Item().setTranslationKey("gun_stock")
 					.setCreativeTab(ReforgedMod.tabReforged));
 			registrationList.add(ReforgedAdditions.MUSKET = new ItemMusket());
 			if (GlobalValues.KNIFE) {
@@ -173,9 +173,9 @@ public class ReforgedRegistry {
 		}
 
 		if (GlobalValues.CANNON) {
-			registrationList.add(ReforgedAdditions.CANNON = new ItemCannon().setUnlocalizedName("cannon")
+			registrationList.add(ReforgedAdditions.CANNON = new ItemCannon().setTranslationKey("cannon")
 					.setCreativeTab(ReforgedMod.tabReforged));
-			registrationList.add(ReforgedAdditions.CANNON_BALL = new Item().setUnlocalizedName("cannon_ball")
+			registrationList.add(ReforgedAdditions.CANNON_BALL = new Item().setTranslationKey("cannon_ball")
 					.setCreativeTab(ReforgedMod.tabReforged));
 		}
 	}
@@ -243,7 +243,7 @@ public class ReforgedRegistry {
 		IForgeRegistry<Block> reg = event.getRegistry();
 		for (Block block : registrationListBlocks) {
 			reg.register(block
-					.setRegistryName(new ResourceLocation(ReforgedMod.ID, block.getUnlocalizedName().substring(5))));
+					.setRegistryName(new ResourceLocation(ReforgedMod.ID, block.getTranslationKey().substring(5))));
 		}
 	}
 
@@ -254,12 +254,12 @@ public class ReforgedRegistry {
 		// Register all Items
 		for (Item item : registrationList) {
 			reg.register(
-					item.setRegistryName(new ResourceLocation(ReforgedMod.ID, item.getUnlocalizedName().substring(5))));
+					item.setRegistryName(new ResourceLocation(ReforgedMod.ID, item.getTranslationKey().substring(5))));
 		}
 		for (Block block : registrationListBlocks) {
 			ItemBlock itemBlock = new ItemBlock(block);
 			itemBlock.setRegistryName(block.getRegistryName());
-			ReforgedMod.proxy.registerItemRenderer(itemBlock, 0, block.getUnlocalizedName().substring(5));
+			ReforgedMod.proxy.registerItemRenderer(itemBlock, 0, block.getTranslationKey().substring(5));
 			reg.register(itemBlock);
 		}
 

--- a/src/main/java/org/silvercatcher/reforged/api/AReforgedThrowable.java
+++ b/src/main/java/org/silvercatcher/reforged/api/AReforgedThrowable.java
@@ -33,7 +33,7 @@ public abstract class AReforgedThrowable extends EntityThrowable {
 		motionZ = MathHelper.cos(rotationYaw / 180.0F * (float) Math.PI)
 				* MathHelper.cos(rotationPitch / 180.0F * (float) Math.PI);
 		motionY = -MathHelper.sin(rotationPitch / 180.0F * (float) Math.PI);
-		setThrowableHeading(motionX, motionY, motionZ, 1.5F, 1.0F);
+		shoot(motionX, motionY, motionZ, 1.5F, 1.0F);
 	}
 
 	public AReforgedThrowable(World worldIn, String damageName) {

--- a/src/main/java/org/silvercatcher/reforged/api/AReloadable.java
+++ b/src/main/java/org/silvercatcher/reforged/api/AReloadable.java
@@ -25,14 +25,16 @@ import javax.annotation.Nullable;
 
 public abstract class AReloadable extends Item implements ItemExtension {
 
-	private final String shootsound;
+	private final String shootSound, reloadSound;
 
-	public AReloadable(String name, String shootsound) {
+	public AReloadable(String name, String shootSound, String reloadSound) {
 		setMaxStackSize(1);
 		setMaxDamage(100);
 		setTranslationKey(name);
 		setCreativeTab(ReforgedMod.tabReforged);
-		this.shootsound = shootsound;
+
+		this.shootSound = shootSound;
+		this.reloadSound = reloadSound;
 
 		addPropertyOverride(new ResourceLocation("loading"), new IItemPropertyGetter() {
 			@SideOnly(Side.CLIENT)
@@ -110,10 +112,10 @@ public abstract class AReloadable extends Item implements ItemExtension {
 
 		if (compound.getInteger(CompoundTags.TIME) <= 0) {
 			if (playerIn.capabilities.isCreativeMode || Helpers.consumeInventoryItem(playerIn, getAmmo())) {
-				Helpers.playSound(worldIn, playerIn, "shotgun_reload", 1.0f, 1.5f);
+				Helpers.playSound(worldIn, playerIn, reloadSound, 1.0f, 1.5f);
 				compound.setInteger(CompoundTags.TIME, 1);
 			} else {
-				Helpers.playSound(worldIn, playerIn, "shotgun_reload", 1.0f, 0.7f);
+				Helpers.playSound(worldIn, playerIn, reloadSound, 1.0f, 0.7f);
 				return new ActionResult<>(EnumActionResult.FAIL, heldStack);
 			}
 		}
@@ -135,7 +137,7 @@ public abstract class AReloadable extends Item implements ItemExtension {
 				if (!player.world.isRemote) {
 					compound.setInteger(CompoundTags.TIME, getReloadTotal());
 					player.resetActiveHand();
-					Helpers.playSound(player.world, player, "shotgun_reload", 1.0f, 1.0f);
+					Helpers.playSound(player.world, player, reloadSound, 1.0f, 1.0f);
 
 					// prevent players from accidentally shooting immediately after reloading
 					if (player instanceof EntityPlayer)
@@ -170,7 +172,7 @@ public abstract class AReloadable extends Item implements ItemExtension {
 			}
 
 			compound.setInteger(CompoundTags.TIME, 0);
-			Helpers.playSound(worldIn, playerIn, shootsound, 1f, 1f);
+			Helpers.playSound(worldIn, playerIn, shootSound, 1f, 1f);
 		}
 	}
 

--- a/src/main/java/org/silvercatcher/reforged/api/AReloadable.java
+++ b/src/main/java/org/silvercatcher/reforged/api/AReloadable.java
@@ -33,7 +33,7 @@ public abstract class AReloadable extends ItemBow implements ItemExtension {
 	public AReloadable(String name, String shootsound) {
 		setMaxStackSize(1);
 		setMaxDamage(100);
-		setUnlocalizedName(name);
+		setTranslationKey(name);
 		setCreativeTab(ReforgedMod.tabReforged);
 		this.shootsound = shootsound;
 	}

--- a/src/main/java/org/silvercatcher/reforged/blocks/BlockCaltrop.java
+++ b/src/main/java/org/silvercatcher/reforged/blocks/BlockCaltrop.java
@@ -26,7 +26,7 @@ public class BlockCaltrop extends BlockContainer implements BlockExtension {
 
 	public BlockCaltrop() {
 		super(Material.GRASS);
-		setUnlocalizedName("caltrop");
+		setTranslationKey("caltrop");
 		setCreativeTab(ReforgedMod.tabReforged);
 		setResistance(30);
 	}
@@ -74,7 +74,7 @@ public class BlockCaltrop extends BlockContainer implements BlockExtension {
 	}
 
 	@Override
-	public void onEntityCollidedWithBlock(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
+	public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn) {
 		if (entityIn instanceof EntityLivingBase) {
 			EntityLivingBase e = (EntityLivingBase) entityIn;
 			e.attackEntityFrom(new DamageSource("caltrop").setDamageBypassesArmor(), CommonProxy.damage_caltrop);

--- a/src/main/java/org/silvercatcher/reforged/entities/EntityCrossbowBolt.java
+++ b/src/main/java/org/silvercatcher/reforged/entities/EntityCrossbowBolt.java
@@ -394,7 +394,7 @@ public class EntityCrossbowBolt extends Entity implements IProjectile {
 			this.setIsCritical(false);
 
 			if (iblockstate.getMaterial() != Material.AIR) {
-				this.inTile.onEntityCollidedWithBlock(this.world, blockpos, iblockstate, this);
+				this.inTile.onEntityCollision(this.world, blockpos, iblockstate, this);
 			}
 		}
 	}
@@ -621,7 +621,7 @@ public class EntityCrossbowBolt extends Entity implements IProjectile {
 		float f = -MathHelper.sin(yaw * 0.017453292F) * MathHelper.cos(pitch * 0.017453292F);
 		float f1 = -MathHelper.sin(pitch * 0.017453292F);
 		float f2 = MathHelper.cos(yaw * 0.017453292F) * MathHelper.cos(pitch * 0.017453292F);
-		this.setThrowableHeading(f, f1, f2, velocity, inaccuracy);
+		this.shoot(f, f1, f2, velocity, inaccuracy);
 		this.motionX += shooter.motionX;
 		this.motionZ += shooter.motionZ;
 
@@ -638,7 +638,7 @@ public class EntityCrossbowBolt extends Entity implements IProjectile {
 		int i = EnchantmentHelper.getMaxEnchantmentLevel(Enchantments.POWER, p_190547_1_);
 		int j = EnchantmentHelper.getMaxEnchantmentLevel(Enchantments.PUNCH, p_190547_1_);
 		this.setDamage(p_190547_2_ * 2.0F + this.rand.nextGaussian() * 0.25D
-				+ this.world.getDifficulty().getDifficultyId() * 0.11F);
+				+ this.world.getDifficulty().getId() * 0.11F);
 
 		if (i > 0) {
 			this.setDamage(this.getDamage() + i * 0.5D + 0.5D);
@@ -714,7 +714,7 @@ public class EntityCrossbowBolt extends Entity implements IProjectile {
 	 * direction.
 	 */
 	@Override
-	public void setThrowableHeading(double x, double y, double z, float velocity, float inaccuracy) {
+	public void shoot(double x, double y, double z, float velocity, float inaccuracy) {
 		float f = MathHelper.sqrt(x * x + y * y + z * z);
 		x = x / f;
 		y = y / f;

--- a/src/main/java/org/silvercatcher/reforged/entities/EntityDart.java
+++ b/src/main/java/org/silvercatcher/reforged/entities/EntityDart.java
@@ -39,7 +39,7 @@ public class EntityDart extends AReforgedThrowable {
 	}
 
 	public String getEffect() {
-		return ((ItemDart) getItemStack().getItem()).getUnlocalizedName().substring(10);
+		return ((ItemDart) getItemStack().getItem()).getTranslationKey().substring(10);
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class EntityDart extends AReforgedThrowable {
 
 	public void setItemStack(ItemStack stack) {
 
-		if (stack == null || stack.isEmpty() || !(stack.getItem().getUnlocalizedName().contains("dart"))) {
+		if (stack == null || stack.isEmpty() || !(stack.getItem().getTranslationKey().contains("dart"))) {
 			throw new IllegalArgumentException("Invalid Itemstack!");
 		}
 		dataManager.set(STACK, stack);

--- a/src/main/java/org/silvercatcher/reforged/items/others/ItemArrowBundle.java
+++ b/src/main/java/org/silvercatcher/reforged/items/others/ItemArrowBundle.java
@@ -7,7 +7,7 @@ public class ItemArrowBundle extends ExtendedItem {
 	public ItemArrowBundle() {
 		super();
 		setMaxStackSize(16);
-		setUnlocalizedName("arrow_bundle");
+		setTranslationKey("arrow_bundle");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/others/ItemBulletBlunderbuss.java
+++ b/src/main/java/org/silvercatcher/reforged/items/others/ItemBulletBlunderbuss.java
@@ -7,7 +7,7 @@ public class ItemBulletBlunderbuss extends ExtendedItem {
 	public ItemBulletBlunderbuss() {
 		super();
 		setMaxStackSize(64);
-		setUnlocalizedName("blunderbuss_bullet");
+		setTranslationKey("blunderbuss_bullet");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/others/ItemBulletMusket.java
+++ b/src/main/java/org/silvercatcher/reforged/items/others/ItemBulletMusket.java
@@ -7,7 +7,7 @@ public class ItemBulletMusket extends ExtendedItem {
 	public ItemBulletMusket() {
 		super();
 		setMaxStackSize(64);
-		setUnlocalizedName("musket_bullet");
+		setTranslationKey("musket_bullet");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/others/ItemCrossbowBolt.java
+++ b/src/main/java/org/silvercatcher/reforged/items/others/ItemCrossbowBolt.java
@@ -7,7 +7,7 @@ public class ItemCrossbowBolt extends ExtendedItem {
 	public ItemCrossbowBolt() {
 		super();
 		setMaxStackSize(64);
-		setUnlocalizedName("crossbow_bolt");
+		setTranslationKey("crossbow_bolt");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/others/ItemDart.java
+++ b/src/main/java/org/silvercatcher/reforged/items/others/ItemDart.java
@@ -6,7 +6,7 @@ public class ItemDart extends ExtendedItem {
 
 	public ItemDart(String effect) {
 		super();
-		setUnlocalizedName("dart_" + effect);
+		setTranslationKey("dart_" + effect);
 		setMaxStackSize(64);
 	}
 

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBattleAxe.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBattleAxe.java
@@ -26,12 +26,12 @@ public class ItemBattleAxe extends ItemAxe implements ItemExtension, IZombieEqui
 	}
 
 	public ItemBattleAxe(ToolMaterial material, boolean unbreakable) {
-		super(material, material.getDamageVsEntity() * 1.5f + 4f, -3.0F);
+		super(material, material.getAttackDamage() * 1.5f + 4f, -3.0F);
 		setMaxStackSize(1);
 
 		this.unbreakable = unbreakable;
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
-		setUnlocalizedName(materialDefinition.getPrefixedName("battleaxe"));
+		setTranslationKey(materialDefinition.getPrefixedName("battleaxe"));
 		setMaxDamage(materialDefinition.getMaxUses());
 
 		setCreativeTab(ReforgedMod.tabReforged);
@@ -60,7 +60,7 @@ public class ItemBattleAxe extends ItemAxe implements ItemExtension, IZombieEqui
 	}
 
 	@Override
-	public float getStrVsBlock(ItemStack stack, IBlockState block) {
+	public float getDestroySpeed(ItemStack stack, IBlockState block) {
 
 		return effectiveAgainst(block) ? materialDefinition.getEfficiencyOnProperMaterial() + 0.5f : 1f;
 	}

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlowGun.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlowGun.java
@@ -16,7 +16,7 @@ public class ItemBlowGun extends ExtendedItem {
 	public ItemBlowGun() {
 
 		super();
-		setUnlocalizedName("blowgun");
+		setTranslationKey("blowgun");
 		setMaxStackSize(1);
 		setMaxDamage(40);
 	}

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlunderbuss.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlunderbuss.java
@@ -13,7 +13,7 @@ import net.minecraft.world.World;
 public class ItemBlunderbuss extends AReloadable {
 
 	public ItemBlunderbuss() {
-		super("blunderbuss", "shotgun_shoot");
+		super("blunderbuss", "shotgun_shoot", "shotgun_reload");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlunderbuss.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBlunderbuss.java
@@ -1,21 +1,24 @@
 package org.silvercatcher.reforged.items.weapons;
 
+import net.minecraft.item.Item;
 import org.silvercatcher.reforged.api.AReloadable;
 import org.silvercatcher.reforged.api.ReforgedAdditions;
 import org.silvercatcher.reforged.entities.EntityBulletBlunderbuss;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
 
 public class ItemBlunderbuss extends AReloadable {
 
 	public ItemBlunderbuss() {
 		super("blunderbuss", "shotgun_shoot");
+	}
+
+	@Override
+	public Item getAmmo() {
+		return ReforgedAdditions.BLUNDERBUSS_SHOT;
 	}
 
 	@Override
@@ -44,12 +47,6 @@ public class ItemBlunderbuss extends AReloadable {
 	public int getReloadTotal() {
 
 		return 40;
-	}
-
-	@Override
-	public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand hand) {
-		setAmmo(ReforgedAdditions.BLUNDERBUSS_SHOT);
-		return super.onItemRightClick(worldIn, playerIn, hand);
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBoomerang.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemBoomerang.java
@@ -27,7 +27,7 @@ public class ItemBoomerang extends ExtendedItem {
 		setMaxStackSize(1);
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 		setMaxDamage((int) (materialDefinition.getMaxUses() * 0.8f));
-		setUnlocalizedName(materialDefinition.getPrefixedName("boomerang"));
+		setTranslationKey(materialDefinition.getPrefixedName("boomerang"));
 	}
 
 	/**

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCannon.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCannon.java
@@ -13,7 +13,7 @@ public class ItemCannon extends ExtendedItem {
 
 	public ItemCannon() {
 		super();
-		setUnlocalizedName("cannon");
+		setTranslationKey("cannon");
 		setMaxStackSize(1);
 	}
 	

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCrossbow.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCrossbow.java
@@ -37,7 +37,7 @@ public class ItemCrossbow extends ItemBow implements ItemExtension {
 	public ItemCrossbow() {
 		setMaxStackSize(1);
 		setMaxDamage(100);
-		setUnlocalizedName("crossbow");
+		setTranslationKey("crossbow");
 		setCreativeTab(ReforgedMod.tabReforged);
 		addPropertyOverride(new ResourceLocation("pull"), new IItemPropertyGetter() {
 			@Override
@@ -79,7 +79,7 @@ public class ItemCrossbow extends ItemBow implements ItemExtension {
 								: I18n.format("item.musket.loadstate.loading"))));
 	}
 
-	private ItemStack findAmmo(EntityPlayer player) {
+	protected ItemStack findAmmo(EntityPlayer player) {
 		if (this.isArrow(player.getHeldItem(EnumHand.OFF_HAND))) {
 			return player.getHeldItem(EnumHand.OFF_HAND);
 		} else if (this.isArrow(player.getHeldItem(EnumHand.MAIN_HAND))) {

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCrossbow.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemCrossbow.java
@@ -1,103 +1,44 @@
 package org.silvercatcher.reforged.items.weapons;
 
-import java.util.List;
 import java.util.Random;
 
 import javax.annotation.Nullable;
 
-import org.silvercatcher.reforged.ReforgedMod;
 import org.silvercatcher.reforged.api.*;
 import org.silvercatcher.reforged.entities.EntityCrossbowBolt;
-import org.silvercatcher.reforged.util.Helpers;
 
-import com.google.common.collect.Multimap;
-
-import net.minecraft.client.resources.I18n;
-import net.minecraft.client.util.ITooltipFlag;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityArrow.PickupStatus;
 import net.minecraft.item.*;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class ItemCrossbow extends ItemBow implements ItemExtension {
-
-	public static final byte empty = 0;
-
-	public static final byte loading = 1;
-
-	public static final byte loaded = 2;
+public class ItemCrossbow extends AReloadable {
 
 	public ItemCrossbow() {
-		setMaxStackSize(1);
-		setMaxDamage(100);
-		setTranslationKey("crossbow");
-		setCreativeTab(ReforgedMod.tabReforged);
+		super("crossbow", "crossbow_shoot", "crossbow_reload");
 		addPropertyOverride(new ResourceLocation("pull"), new IItemPropertyGetter() {
 			@Override
 			@SideOnly(Side.CLIENT)
 			public float apply(ItemStack stack, @Nullable World worldIn, @Nullable EntityLivingBase entityIn) {
-				float mrl = 0;
-				if (entityIn != null && entityIn instanceof EntityPlayer) {
-					EntityPlayer player = (EntityPlayer) entityIn;
-					if (stack.getItem() instanceof ItemCrossbow && player.getActiveHand() == EnumHand.MAIN_HAND) {
-						if (getLoadState(stack) == loading) {
-							int left = getReloadLeft(stack, player);
-							if (left > 14) {
-								mrl = 1;
-							} else if (left > 9) {
-								mrl = 2;
-							} else if (left > 4) {
-								mrl = 4;
-							} else if (left >= 0) {
-								mrl = 5;
-							}
-						} else if (getLoadState(stack) == loaded) {
-							mrl = 3;
-						}
-					}
-				}
-				return mrl;
+				int reloadTime = stack.getTagCompound().getInteger(CompoundTags.TIME);
+				if (reloadTime <= 0)
+					return 0f;
+
+				int reloadTimeLeft = getReloadTotal() - reloadTime;
+				if (reloadTimeLeft > 14)
+					return 1f;
+				if (reloadTimeLeft > 9)
+					return 2f;
+				if (reloadTimeLeft > 4)
+					return 4f;
+				if (reloadTimeLeft > 0)
+					return 5f;
+				return 3f;
 			}
 		});
-	}
-
-	@Override
-	public void addInformation(ItemStack stack, World worldIn, List<String> tooltip, ITooltipFlag advanced) {
-
-		byte loadState = giveCompound(stack).getByte(CompoundTags.AMMUNITION);
-
-		tooltip.add(I18n.format("item.musket.loadstate") + ": "
-				+ (loadState == empty ? I18n.format("item.musket.loadstate.empty")
-						: (loadState == loaded ? I18n.format("item.musket.loadstate.loaded")
-								: I18n.format("item.musket.loadstate.loading"))));
-	}
-
-	protected ItemStack findAmmo(EntityPlayer player) {
-		if (this.isArrow(player.getHeldItem(EnumHand.OFF_HAND))) {
-			return player.getHeldItem(EnumHand.OFF_HAND);
-		} else if (this.isArrow(player.getHeldItem(EnumHand.MAIN_HAND))) {
-			return player.getHeldItem(EnumHand.MAIN_HAND);
-		} else {
-			for (int i = 0; i < player.inventory.getSizeInventory(); ++i) {
-				ItemStack itemstack = player.inventory.getStackInSlot(i);
-				if (this.isArrow(itemstack)) {
-					return itemstack;
-				}
-			}
-			return ItemStack.EMPTY;
-		}
-	}
-
-	@Override
-	public Multimap getAttributeModifiers(ItemStack stack) {
-		return ItemExtension.super.getAttributeModifiers(stack);
 	}
 
 	@Override
@@ -106,144 +47,19 @@ public class ItemCrossbow extends ItemBow implements ItemExtension {
 	}
 
 	@Override
-	public EnumAction getItemUseAction(ItemStack stack) {
-
-		byte loadState = getLoadState(stack);
-
-		if (loadState == loading) {
-			if (ReforgedMod.battlegearDetected)
-				return EnumAction.BOW;
-			else
-				return EnumAction.BLOCK;
-		}
-		if (loadState == loaded)
-			return EnumAction.BOW;
-		return EnumAction.NONE;
-	}
-
-	public byte getLoadState(ItemStack stack) {
-		return giveCompound(stack).getByte(CompoundTags.AMMUNITION);
-	}
-
-	@Override
-	public int getMaxItemUseDuration(ItemStack stack) {
-
-		byte loadState = giveCompound(stack).getByte(CompoundTags.AMMUNITION);
-
-		if (loadState == loading)
-			return getReloadTotal();
-
-		return super.getMaxItemUseDuration(stack);
-	}
-
-	public int getReloadLeft(ItemStack stack, EntityPlayer player) {
-		return (getReloadTotal() - getReloadTime(stack));
-	}
-
-	public int getReloadTime(ItemStack stack) {
-		return giveCompound(stack).getInteger(CompoundTags.TIME);
-	}
-
 	public int getReloadTotal() {
 		return 20;
 	}
 
-	public NBTTagCompound giveCompound(ItemStack stack) {
-
-		NBTTagCompound compound = CompoundTags.giveCompound(stack);
-
-		if (!compound.hasKey(CompoundTags.AMMUNITION)) {
-
-			compound.setByte(CompoundTags.AMMUNITION, empty);
-		}
-		return compound;
-	}
-
 	@Override
-	protected boolean isArrow(ItemStack stack) {
-		return stack.getItem() instanceof ItemArrow;
-	}
-
-	@Override
-	public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand hand) {
-		if (hand == EnumHand.MAIN_HAND) {
-			NBTTagCompound compound = giveCompound(playerIn.getHeldItemMainhand());
-
-			byte loadState = compound.getByte(CompoundTags.AMMUNITION);
-
-			if (loadState == empty) {
-				if (playerIn.capabilities.isCreativeMode
-						|| Helpers.consumeInventoryItem(playerIn, ReforgedAdditions.CROSSBOW_BOLT)) {
-					loadState = loading;
-					if (compound.getByte(CompoundTags.AMMUNITION) == empty) {
-						compound.setBoolean(CompoundTags.STARTED, true);
-						compound.setInteger(CompoundTags.TIME, 0);
-					}
-				} else {
-					Helpers.playSound(worldIn, playerIn, "crossbow_reload", 1.0f, 0.7f);
-				}
-			}
-
-			compound.setByte(CompoundTags.AMMUNITION, loadState);
-
-			if (compound.getInteger(CompoundTags.TIME) <= 0 || !worldIn.isRemote
-					|| (worldIn.isRemote && compound.getInteger(CompoundTags.TIME) >= getReloadTotal() - 1)) {
-				playerIn.setActiveHand(hand);
-			}
-
-			return new ActionResult(EnumActionResult.SUCCESS, playerIn.getHeldItemMainhand());
-		}
-		return new ActionResult<ItemStack>(EnumActionResult.FAIL, playerIn.getHeldItemOffhand());
-	}
-
-	@Override
-	public EnumActionResult onItemUse(EntityPlayer player, World worldIn, BlockPos pos, EnumHand hand,
-			EnumFacing facing, float hitX, float hitY, float hitZ) {
-		return EnumActionResult.PASS;
-	}
-
-	@Override
-	public ItemStack onItemUseFinish(ItemStack stack, World worldIn, EntityLivingBase playerIn) {
-		byte loadState = giveCompound(stack).getByte(CompoundTags.AMMUNITION);
-		if (loadState == loading) {
-			loadState = loaded;
-		}
-		giveCompound(stack).setByte(CompoundTags.AMMUNITION, loadState);
-		return stack;
-	}
-
-	@Override
-	public void onPlayerStoppedUsing(ItemStack stack, World worldIn, EntityLivingBase playerInl, int timeLeft) {
-		if (!worldIn.isRemote && playerInl instanceof EntityPlayer) {
-			EntityPlayer playerIn = (EntityPlayer) playerInl;
-			NBTTagCompound compound = giveCompound(stack);
-			byte loadState = compound.getByte(CompoundTags.AMMUNITION);
-			if (loadState == loaded) {
-				Helpers.playSound(worldIn, playerIn, "crossbow_shoot", 1f, 1f);
-				shoot(worldIn, playerIn, new ItemStack(ReforgedAdditions.CROSSBOW_BOLT));
-				if (!playerIn.capabilities.isCreativeMode
-						&& (stack.getItem().isDamageable() && stack.attemptDamageItem(5, itemRand, null))) {
-					playerIn.renderBrokenItemStack(stack);
-					Helpers.destroyCurrentEquippedItem(playerIn);
-				}
-				compound.setByte(CompoundTags.AMMUNITION, empty);
-				compound.setBoolean(CompoundTags.STARTED, false);
-			}
-			compound.setInteger(CompoundTags.TIME, -1);
-		}
-	}
-
-	@Override
-	public void onUpdate(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
-		super.onUpdate(stack, worldIn, entityIn, itemSlot, isSelected);
-		if (giveCompound(stack).getBoolean(CompoundTags.STARTED) && getLoadState(stack) == loading) {
-			giveCompound(stack).setInteger(CompoundTags.TIME, getReloadTime(stack) + 1);
-		}
+	public Item getAmmo() {
+		return ReforgedAdditions.CROSSBOW_BOLT;
 	}
 
 	public void shoot(World worldIn, EntityLivingBase playerIn, ItemStack stack) {
 		EntityCrossbowBolt a = new EntityCrossbowBolt(worldIn, playerIn);
-		a.setAim(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, getArrowVelocity(40) * 3.0F, 1.0F);
+		a.setAim(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F,
+				ItemBow.getArrowVelocity(40) * 3.0F, 1.0F);
 		a.pickupStatus = PickupStatus.getByOrdinal(new Random().nextInt(2));
 		a.setDamage(8.0D);
 		worldIn.spawnEntity(a);

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemDirk.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemDirk.java
@@ -32,7 +32,7 @@ public class ItemDirk extends ItemSword implements ItemExtension, IZombieEquippa
 		this.unbreakable = unbreakable;
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 
-		setUnlocalizedName(materialDefinition.getPrefixedName("dirk"));
+		setTranslationKey(materialDefinition.getPrefixedName("dirk"));
 		setMaxDamage(materialDefinition.getMaxUses());
 		setMaxStackSize(1);
 	}

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemDynamite.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemDynamite.java
@@ -13,7 +13,7 @@ public class ItemDynamite extends ExtendedItem {
 
 	public ItemDynamite() {
 		super();
-		setUnlocalizedName("dynamite");
+		setTranslationKey("dynamite");
 		setMaxStackSize(64);
 	}
 

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemFireRod.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemFireRod.java
@@ -17,7 +17,7 @@ public class ItemFireRod extends ExtendedItem {
 
 	public ItemFireRod() {
 		super();
-		setUnlocalizedName("firerod");
+		setTranslationKey("firerod");
 		setMaxStackSize(32);
 	}
 

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemJavelin.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemJavelin.java
@@ -17,7 +17,7 @@ public class ItemJavelin extends ExtendedItem {
 
 	public ItemJavelin() {
 		super();
-		setUnlocalizedName("javelin");
+		setTranslationKey("javelin");
 		setMaxStackSize(8);
 		setMaxDamage(32);
 	}

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKatana.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKatana.java
@@ -30,7 +30,7 @@ public class ItemKatana extends ItemSword implements ItemExtension, IZombieEquip
 		this.unbreakable = unbreakable;
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 
-		setUnlocalizedName(materialDefinition.getPrefixedName("katana"));
+		setTranslationKey(materialDefinition.getPrefixedName("katana"));
 		setMaxDamage(materialDefinition.getMaxUses());
 		setMaxStackSize(1);
 		setCreativeTab(ReforgedMod.tabReforged);

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKeris.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKeris.java
@@ -24,7 +24,7 @@ public class ItemKeris extends ItemSword implements ItemExtension {
 
 		materialDefinition = MaterialManager.getMaterialDefinition(ToolMaterial.GOLD);
 
-		setUnlocalizedName("keris");
+		setTranslationKey("keris");
 		setMaxDamage(materialDefinition.getMaxUses());
 		setMaxStackSize(1);
 		setCreativeTab(ReforgedMod.tabReforged);
@@ -36,7 +36,7 @@ public class ItemKeris extends ItemSword implements ItemExtension {
 	}
 
 	@Override
-	public float getDamageVsEntity() {
+	public float getAttackDamage() {
 		return getHitDamage();
 	}
 

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKnife.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemKnife.java
@@ -33,7 +33,7 @@ public class ItemKnife extends ItemSword implements ItemExtension, IZombieEquipp
 		this.unbreakable = unbreakable;
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 
-		setUnlocalizedName(materialDefinition.getPrefixedName("knife"));
+		setTranslationKey(materialDefinition.getPrefixedName("knife"));
 		setMaxDamage(materialDefinition.getMaxUses());
 		setMaxStackSize(1);
 	}
@@ -60,7 +60,7 @@ public class ItemKnife extends ItemSword implements ItemExtension, IZombieEquipp
 		Vec3d attackervec = new Vec3d(attacker.posX - target.posX,
 				(attacker.getEntityBoundingBox().minY + attacker.height / 2) - target.posY + target.getEyeHeight(),
 				attacker.posZ - target.posZ);
-		double d0 = attackervec.lengthVector();
+		double d0 = attackervec.length();
 
 		double d1 = look.dotProduct(attackervec);
 

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMace.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMace.java
@@ -27,7 +27,7 @@ public class ItemMace extends ExtendedItem implements IZombieEquippable {
 		setMaxStackSize(1);
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 		setMaxDamage((int) (materialDefinition.getMaxUses() * 0.5f));
-		setUnlocalizedName(materialDefinition.getPrefixedName("mace"));
+		setTranslationKey(materialDefinition.getPrefixedName("mace"));
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusket.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusket.java
@@ -1,21 +1,24 @@
 package org.silvercatcher.reforged.items.weapons;
 
+import net.minecraft.item.Item;
 import org.silvercatcher.reforged.api.AReloadable;
 import org.silvercatcher.reforged.api.ReforgedAdditions;
 import org.silvercatcher.reforged.entities.EntityBulletMusket;
 
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
 
 public class ItemMusket extends AReloadable {
 
 	public ItemMusket() {
 		super("musket", "musket_shoot");
+	}
+
+	@Override
+	public Item getAmmo() {
+		return ReforgedAdditions.MUSKET_BULLET;
 	}
 
 	@Override
@@ -50,14 +53,6 @@ public class ItemMusket extends AReloadable {
 		if (stack.getItem().isDamageable())
 			stack.damageItem(1, attacker);
 		return true;
-	}
-
-	@Override
-	public ActionResult<ItemStack> onItemRightClick(World worldIn, EntityPlayer playerIn, EnumHand hand) {
-		if (hand == EnumHand.MAIN_HAND) {
-			setAmmo(ReforgedAdditions.MUSKET_BULLET);
-		}
-		return super.onItemRightClick(worldIn, playerIn, hand);
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusket.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusket.java
@@ -13,7 +13,7 @@ import net.minecraft.world.World;
 public class ItemMusket extends AReloadable {
 
 	public ItemMusket() {
-		super("musket", "musket_shoot");
+		super("musket", "musket_shoot", "shotgun_reload");
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusketWithBayonet.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemMusketWithBayonet.java
@@ -22,7 +22,7 @@ public class ItemMusketWithBayonet extends ItemMusket {
 
 		this.unbreakable = unbreakable;
 		this.materialDefinition = MaterialManager.getMaterialDefinition(material);
-		setUnlocalizedName(materialDefinition.getPrefixedName("musket"));
+		setTranslationKey(materialDefinition.getPrefixedName("musket"));
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemNestOfBees.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemNestOfBees.java
@@ -28,7 +28,7 @@ public class ItemNestOfBees extends ExtendedItem {
 
 	public ItemNestOfBees() {
 		super();
-		setUnlocalizedName("nest_of_bees");
+		setTranslationKey("nest_of_bees");
 		setMaxDamage(80);
 		setMaxStackSize(1);
 		addPropertyOverride(new ResourceLocation("empty"), new IItemPropertyGetter() {
@@ -146,10 +146,10 @@ public class ItemNestOfBees extends ExtendedItem {
 
 		if (!world.isRemote) {
 			EntityArrow arrow = new ItemArrow().createArrow(world, new ItemStack(Items.ARROW), shooter);
-			arrow.setAim(shooter, shooter.rotationPitch, shooter.rotationYaw, 0.0F, ItemBow.getArrowVelocity(40) * 3.0F,
+			arrow.shoot(shooter, shooter.rotationPitch, shooter.rotationYaw, 0.0F, ItemBow.getArrowVelocity(40) * 3.0F,
 					1.0F);
 			arrow.setDamage(2);
-			arrow.setThrowableHeading(arrow.motionX, arrow.motionY, arrow.motionZ, 3 + itemRand.nextFloat() / 2f, 1.5f);
+			arrow.shoot(arrow.motionX, arrow.motionY, arrow.motionZ, 3 + itemRand.nextFloat() / 2f, 1.5f);
 			world.spawnEntity(arrow);
 		}
 		world.playSound(null, shooter.posX, shooter.posY, shooter.posZ, SoundEvents.ENTITY_FIREWORK_LAUNCH,

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemPike.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemPike.java
@@ -23,7 +23,7 @@ public class ItemPike extends ExtendedItem {
 		setMaxStackSize(1);
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 		setMaxDamage((int) (materialDefinition.getMaxUses() * 0.5f));
-		setUnlocalizedName(materialDefinition.getPrefixedName("pike"));
+		setTranslationKey(materialDefinition.getPrefixedName("pike"));
 	}
 
 	@Override

--- a/src/main/java/org/silvercatcher/reforged/items/weapons/ItemSaber.java
+++ b/src/main/java/org/silvercatcher/reforged/items/weapons/ItemSaber.java
@@ -30,7 +30,7 @@ public class ItemSaber extends ItemSword implements ItemExtension, IZombieEquipp
 		this.unbreakable = unbreakable;
 		materialDefinition = MaterialManager.getMaterialDefinition(material);
 
-		setUnlocalizedName(materialDefinition.getPrefixedName("saber"));
+		setTranslationKey(materialDefinition.getPrefixedName("saber"));
 
 		setCreativeTab(ReforgedMod.tabReforged);
 		setMaxStackSize(1);

--- a/src/main/java/org/silvercatcher/reforged/material/MaterialDefinition.java
+++ b/src/main/java/org/silvercatcher/reforged/material/MaterialDefinition.java
@@ -42,11 +42,11 @@ public class MaterialDefinition {
 	}
 
 	public float getDamageVsEntity() {
-		return material.getDamageVsEntity();
+		return material.getAttackDamage();
 	}
 
 	public float getEfficiencyOnProperMaterial() {
-		return material.getEfficiencyOnProperMaterial();
+		return material.getEfficiency();
 	}
 
 	public int getEnchantability() {

--- a/src/main/java/org/silvercatcher/reforged/packet/MessageCustomReachAttack.java
+++ b/src/main/java/org/silvercatcher/reforged/packet/MessageCustomReachAttack.java
@@ -26,7 +26,7 @@ public class MessageCustomReachAttack implements IMessage {
 					if (player.inventory.getCurrentItem().getItem() instanceof ICustomReach) {
 						ICustomReach theExtendedReachWeapon = (ICustomReach) player.inventory.getCurrentItem()
 								.getItem();
-						double distanceSq = player.getDistanceSqToEntity(theEntity);
+						double distanceSq = player.getDistanceSq(theEntity);
 						double reachSq = theExtendedReachWeapon.reach() * theExtendedReachWeapon.reach();
 						if (reachSq >= distanceSq) {
 							player.attackTargetEntityWithCurrentItem(theEntity);

--- a/src/main/java/org/silvercatcher/reforged/proxy/ClientProxy.java
+++ b/src/main/java/org/silvercatcher/reforged/proxy/ClientProxy.java
@@ -136,12 +136,12 @@ public class ClientProxy extends CommonProxy {
 
 		for (Item item : ReforgedRegistry.registrationList) {
 			ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(
-					ReforgedMod.ID + ":" + item.getUnlocalizedName().substring(5), inventory));
+					ReforgedMod.ID + ":" + item.getTranslationKey().substring(5), inventory));
 		}
 
 		for (Block item : ReforgedRegistry.registrationListBlocks) {
 			ModelLoader.setCustomModelResourceLocation(Item.getItemFromBlock(item), 0, new ModelResourceLocation(
-					ReforgedMod.ID + ":" + item.getUnlocalizedName().substring(5), inventory));
+					ReforgedMod.ID + ":" + item.getTranslationKey().substring(5), inventory));
 		}
 
 	}

--- a/src/main/java/org/silvercatcher/reforged/util/Helpers.java
+++ b/src/main/java/org/silvercatcher/reforged/util/Helpers.java
@@ -115,7 +115,7 @@ public class Helpers {
 				calcdist = returnMOP.hitVec.distanceTo(pos);
 			}
 			Vec3d lookvec = theRenderViewEntity.getLook(0);
-			Vec3d var8 = pos.addVector(lookvec.x * var2, lookvec.y * var2, lookvec.z * var2);
+			Vec3d var8 = pos.add(lookvec.x * var2, lookvec.y * var2, lookvec.z * var2);
 			Entity pointedEntity = null;
 			float var9 = 1.0F;
 			List<Entity> list = mc.world.getEntitiesWithinAABBExcludingEntity(theRenderViewEntity, theViewBoundingBox

--- a/src/main/resources/assets/reforged/models/item/blunderbuss.json
+++ b/src/main/resources/assets/reforged/models/item/blunderbuss.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/blunderbuss"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/blunderbuss_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/blunderbuss_loading.json
+++ b/src/main/resources/assets/reforged/models/item/blunderbuss_loading.json
@@ -1,0 +1,6 @@
+{
+    "parent": "reforged:item/musket_loading",
+    "textures": {
+        "layer0": "reforged:items/blunderbuss"
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/diamond_musket.json
+++ b/src/main/resources/assets/reforged/models/item/diamond_musket.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/musket_diamond"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/diamond_musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/diamond_musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/diamond_musket_loading.json
@@ -1,0 +1,6 @@
+{
+    "parent": "reforged:item/musket_loading",
+    "textures": {
+        "layer0": "reforged:items/musket_diamond"
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/golden_musket.json
+++ b/src/main/resources/assets/reforged/models/item/golden_musket.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/musket_gold"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/golden_musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/golden_musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/golden_musket_loading.json
@@ -1,0 +1,6 @@
+{
+    "parent": "reforged:item/musket_loading",
+    "textures": {
+        "layer0": "reforged:items/musket_gold"
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/iron_musket.json
+++ b/src/main/resources/assets/reforged/models/item/iron_musket.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/musket_iron"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/iron_musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/iron_musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/iron_musket_loading.json
@@ -1,0 +1,7 @@
+{
+    "parent": "reforged:item/musket_loading",
+
+    "textures": {
+        "layer0": "reforged:items/musket_iron"
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/musket.json
+++ b/src/main/resources/assets/reforged/models/item/musket.json
@@ -10,7 +10,7 @@
             "scale": [ 1.10, 1.10, 1.10 ]
         },
         "firstperson_righthand": {
-            "rotation": [ 344, 273, 25 ],
+            "rotation": [ 10, 283, 25 ],
             "translation": [ 7.00, 2.25, -15.25 ],
             "scale": [ 2.25, 2.25, 2.25 ]
         },
@@ -20,9 +20,17 @@
             "scale": [ 1.10, 1.10, 1.10 ]
         },
         "firstperson_lefthand": {
-            "rotation": [ 154, 87, 165 ],
+            "rotation": [ 180, 77, 165 ],
             "translation": [ 7.00, 2.25, -15.25 ],
             "scale": [ 2.25, 2.25, 2.25 ]
         }
-	}
+	},
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/musket_loading.json
@@ -1,0 +1,15 @@
+{
+    "parent": "reforged:item/musket",
+    "display": {
+      "firstperson_righthand": {
+        "rotation": [ 344, 333, 25 ],
+        "translation": [ 0.00, -2.00, -10.25 ],
+        "scale": [ 2.25, 2.25, 2.25 ]
+      },
+      "firstperson_lefthand": {
+        "rotation": [ 154, 27, 165 ],
+        "translation": [ 0.00, -2.00, -10.25 ],
+        "scale": [ 2.25, 2.25, 2.25 ]
+      }
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/stone_musket.json
+++ b/src/main/resources/assets/reforged/models/item/stone_musket.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/musket_stone"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/stone_musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/stone_musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/stone_musket_loading.json
@@ -1,0 +1,7 @@
+{
+    "parent": "reforged:item/musket_loading",
+
+    "textures": {
+        "layer0": "reforged:items/musket_stone"
+    }
+}

--- a/src/main/resources/assets/reforged/models/item/wooden_musket.json
+++ b/src/main/resources/assets/reforged/models/item/wooden_musket.json
@@ -1,7 +1,14 @@
 {
     "parent": "reforged:item/musket",
-
     "textures": {
         "layer0": "reforged:items/musket_wood"
-    }
+    },
+    "overrides": [
+        {
+            "predicate": {
+                "loading": 1
+            },
+            "model": "reforged:item/wooden_musket_loading"
+        }
+    ]
 }

--- a/src/main/resources/assets/reforged/models/item/wooden_musket_loading.json
+++ b/src/main/resources/assets/reforged/models/item/wooden_musket_loading.json
@@ -1,0 +1,6 @@
+{
+    "parent": "reforged:item/musket_loading",
+    "textures": {
+        "layer0": "reforged:items/musket_wood"
+    }
+}

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "Reforged's resources",
-        "pack_format": 2,
+        "pack_format": 3,
         "_comment": "Reforged's default resources."
     }
 }


### PR DESCRIPTION
Makes the following changes:

* Bumps Gradle version for wrapper to 4.8.1
* Bumps MinecraftForge to 14.23.5.2847
* Bumps deobfuscation mappings to stable_39
* Reworks `AReloadable` and the weapons based on it (muskets and blunderbusses)
  * Reloading system is cleaner and less buggy
    * Fixed bug where guns could be reloaded without holding right click in single-player worlds
    * Fixed bug where partial reloading did not work at all on multiplayer servers
    * Fixed bug where the reloading hotbar overlay caused lighting/transparency issues
  * Guns now play a sound upon starting and finishing reloading
  * Gun models are positioned so that they point at the crosshair in first-person while firing
  * Gun models now tilt to the side while reloading
  * Guns no longer zoom in while reloading and zoom a little bit more while firing
  * Guns now go on cooldown for half a second after reloading to stop players from accidentally firing them by holding right click too long
  * Other internal implementation improvements
* Reimplements the crossbow as an `AReloaded` so that it enjoys the same benefits as above

Also fixes https://github.com/xJon/Tekkit-2/issues/4